### PR TITLE
Add ability to specify cascade for tree

### DIFF
--- a/src/panel_jstree/__init__.py
+++ b/src/panel_jstree/__init__.py
@@ -2,4 +2,4 @@
 from panel_jstree.widgets.jstree import Tree, FileTree
 
 # make sure you update the version in package.json as well
-VERSION = "0.3.4"
+VERSION = "0.3.5"

--- a/src/panel_jstree/bokeh_extensions/jstree.py
+++ b/src/panel_jstree/bokeh_extensions/jstree.py
@@ -42,6 +42,8 @@ class jsTreePlot(HTMLBox):
     multiple = Bool(default=True)
     show_icons = Bool(default=True)
     show_dots = Bool(default=True)
+    cascade = Bool(default=True)
+    cascade_setting = String()
     _last_opened = Dict(String, Any)
     _new_nodes = List(Any)
     _flat_tree = List(Any)

--- a/src/panel_jstree/bokeh_extensions/jstree.ts
+++ b/src/panel_jstree/bokeh_extensions/jstree.ts
@@ -49,13 +49,6 @@ export class jsTreePlotView extends HTMLBoxView {
         set_size(this._container, this.model)
         this.shadow_el.appendChild(this._container);
         // console.log(this._container)
-
-        let kw: {[k: string]: any} = {"checkbox": {
-            "three_state": false,
-            "cascade": "undetermined"
-        }}
-
-        // console.log("plugins: ", this.model.plugins)
         if (this.model.checkbox && !this.model.plugins.includes("checkbox")) {
             this.model.plugins.push("checkbox")
         }
@@ -70,7 +63,11 @@ export class jsTreePlotView extends HTMLBoxView {
                   }
                 },
                 "plugins": this.model.plugins,
-                ...kw
+                checkbox: {
+                    three_state: this.model.cascade_setting == "" ? this.model.cascade : false,
+                    cascade: this.model.cascade_setting == "" ? "up+down+undetermined" : this.model.cascade_setting,
+                    cascade_to_disabled: false,
+                  }
             }
             );
         this.init_callbacks()
@@ -210,7 +207,8 @@ export namespace jsTreePlot {
     multiple: p.Property<boolean>
     show_icons: p.Property<boolean>
     show_dots: p.Property<boolean>
-    drag_and_drop: p.Property<boolean>
+    cascade: p.Property<boolean>
+    cascade_setting: p.Property<any>
     value: p.Property<any>
     _last_opened: p.Property<any>
     _new_nodes: p.Property<any>
@@ -240,7 +238,8 @@ export class jsTreePlot extends HTMLBox {
         multiple:      [ Boolean, true ],
         show_icons:    [ Boolean, true ],
         show_dots:     [ Boolean, true ],
-        drag_and_drop:     [ Boolean, false ],
+        cascade:       [ Boolean, true ],
+        cascade_setting:       [ Any, "" ],
         _last_opened: [ Any, {} ],
         _new_nodes: [ Array(Any), [] ],
         _flat_tree: [ Array(Any), []     ],

--- a/src/panel_jstree/package-lock.json
+++ b/src/panel_jstree/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panel_jstree",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "panel_jstree",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@bokeh/bokehjs": "^3.1",

--- a/src/panel_jstree/package.json
+++ b/src/panel_jstree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panel_jstree",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "jsTree",
   "license": "MIT",
   "keywords": [],

--- a/src/panel_jstree/widgets/jstree.py
+++ b/src/panel_jstree/widgets/jstree.py
@@ -55,6 +55,21 @@ class _TreeBase(Widget):
         "to jsTree."
     )
 
+    cascade = param.Boolean(
+        default=True, doc="Whether to cascade selections up and down the tree, "
+                          "only applicable if checkbox is True "
+                          "Use cascade or cascade_setting, not both"
+    )
+
+    cascade_setting = param.String(
+        default="", doc="The exact jsTree cascade setting to use. "
+                        "Only applicable if checkbox is True "
+                        "Specifying  cascade_setting will override cascade. "
+                        "Options are: 'up', 'down', 'undetermined', "
+                        "'up+down', 'up+undetermined', 'down+undetermined', "
+                        "'up+down+undetermined'"
+    )
+
     _get_children_cb = param.Callable(
         doc="Function that is called to load new children nodes. "
             "First argument should be the text representation of the parent,"
@@ -116,6 +131,24 @@ class _TreeBase(Widget):
             properties["height"] = 100
 
         properties["value"] = self._values
+
+        if properties.get("cascade_setting"):
+            if properties["cascade_setting"] not in (
+                "up",
+                "down",
+                "undetermined",
+                "up+down",
+                "up+undetermined",
+                "down+undetermined",
+                "up+down+undetermined",
+            ):
+                raise ValueError(
+                    "cascade_setting must be one of 'up', 'down', 'undetermined', "
+                    "'up+down', 'up+undetermined', 'down+undetermined', "
+                    "'up+down+undetermined'"
+                )
+            properties["cascade"] = False
+
         return properties
 
     def add_children_on_new_values(self, *event):

--- a/tests/deep_tree.py
+++ b/tests/deep_tree.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import panel as pn
+
+from panel_jstree import Tree
+
+pn.extension("tree", sizing_mode="stretch_width")
+
+data = [
+    {
+        'text': 'Root node 2',
+        'children': [
+            {'text': 'Child 1',
+             'children': [
+                 {'text': 'Child 1.1',
+                  "children": [
+                      {"text": "Child 1.1.1",
+                       "children": [
+                           {"text": "Child 1.1.1.1",
+                            "children": [
+                                {"text": "Child 1.1.1.1.1",
+                                 "children": [
+                                     {"text": "Child 1.1.1.1.1.1"},
+                                 ],
+                                 'state': {'opened': True},
+
+                                 },
+                            ],
+                            'state': {'opened': True},
+                            },
+                       ],
+                       'state': {'opened': True},
+                       },
+                  ],
+                  'state': {'opened': True},
+
+                  },
+             ],
+             'state': {'opened': True},
+             }
+        ],
+        'state': {'opened': True},
+    }
+]
+
+
+def test_base_tree_app():
+    """Construct a BaseTree for manual testing"""
+    tree = Tree(
+        data=data,
+        sizing_mode="stretch_both",
+        cascade=False
+    )
+
+    settings = pn.Param(
+        tree,
+        parameters=[
+            "select_multiple",
+            "show_icons",
+            "show_dots",
+            "checkbox",
+        ]
+    )
+
+    return pn.template.FastListTemplate(
+        site="Taxonomy jsTree",
+        title="Taxonomy Tree",
+        main=[pn.Column(tree)],
+        sidebar=[settings],
+    )
+
+
+if __name__.startswith("bokeh"):
+    test_base_tree_app().servable()
+
+if __name__ == "__main__":
+    pn.serve({Path(__file__).name: test_base_tree_app()}, port=5012, show=False)


### PR DESCRIPTION
Cascade can either be True or False which is full up and down cascade, or cascade_setting can be specified with the options specified in jstree's docs under [checkbox.cascade](https://www.jstree.com/api/#/?f=$.jstree.defaults.checkbox.cascade)